### PR TITLE
remove "Wikipedia:" as interwiki prefix

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -6,7 +6,7 @@ import dotenv
 
 dotenv.load_dotenv()
 
-VERSION = "1.4.2"
+VERSION = "1.4.3"
 DISCORD_KEY = typing.cast(str, os.getenv('DISCORD_BOT'))
 GUILD = int(os.getenv('GUILD'))  # type: ignore
 MOD_CHANNEL = int(os.getenv('MOD_CHANNEL'))  # type: ignore

--- a/wikilink.py
+++ b/wikilink.py
@@ -23,8 +23,7 @@ _VALID_LINK = r"""
 _BRACKET_LINK = re.compile(fr"\[\[{_VALID_LINK}\]\]", re.X)
 _BRACE_LINK = re.compile(fr"\{{\{{{_VALID_LINK}\}}\}}", re.X)
 _WIKI_FAMILIES = AliasDict(
-    {('w', 'testwiki', 'test2wiki', 'nost', 'nostalgia'): 'wikipedia',
-     'wikt': 'wiktionary',
+    {'wikt': 'wiktionary',
      'b': 'wikibooks',
      ('d', 'testwikidata'): 'wikidata',
      'n': 'wikinews',
@@ -34,6 +33,7 @@ _WIKI_FAMILIES = AliasDict(
      'v': 'wikiversity',
      'voy': 'wikivoyage'},
     value_isnt_alias={
+        ('w', 'testwiki', 'test2wiki', 'nost', 'nostalgia'): 'wikipedia',
         ('c', 'commons', 'm', 'meta', 'metawiki', 'incubator'): 'wikimedia',
         'mw': 'mediawiki'
     }


### PR DESCRIPTION
If we ever want to use this not defaulting to enwiki, this will need to
be changed.

closes #7 