### PR TITLE
fix mistake in `wikilnk.VALID_LINK`

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -6,7 +6,7 @@ import dotenv
 
 dotenv.load_dotenv()
 
-VERSION = "1.4.3"
+VERSION = "1.4.4"
 DISCORD_KEY = typing.cast(str, os.getenv('DISCORD_BOT'))
 GUILD = int(os.getenv('GUILD'))  # type: ignore
 MOD_CHANNEL = int(os.getenv('MOD_CHANNEL'))  # type: ignore

--- a/wikilink.py
+++ b/wikilink.py
@@ -17,7 +17,8 @@ _VALID_LINK = r"""
         )
         (\||\]\])
     )
-    (?P<wikilink> [^][<>{}#|]+ )
+    # Can contain an octothorpe but can't start with it.
+    (?P<wikilink> [^][<>{}#|] [^][<>{}|]+ )
     ( \|.*? )?
 """
 _BRACKET_LINK = re.compile(fr"\[\[{_VALID_LINK}\]\]", re.X)


### PR DESCRIPTION
octothorpes are valid characters as long as they're not the *first*
character. (well, even that would be valid on-wiki, but is meaningless
in this context.)